### PR TITLE
KMP: Fix check for call to weak-modules2

### DIFF
--- a/src/soliddriver_checks/api/kmp.py
+++ b/src/soliddriver_checks/api/kmp.py
@@ -260,8 +260,7 @@ class KMPAnalysis:
                         if uk.strip() == kmp_a.strip():
                             unmatched_kmp_alias.remove(uk)
                             break
-                # Keep looping. Can match more than one KMP modalias
-                # Need to remove all from unmatched list.
+                    break
             if not found:
                 unmatched_ker_alias.append(ker_a)
 

--- a/src/soliddriver_checks/api/kmp.py
+++ b/src/soliddriver_checks/api/kmp.py
@@ -453,6 +453,9 @@ class KMPReader:
         for line in lines:
             if "/usr/lib/module-init-tools/weak-modules2" in line:
                 return True
+            # Newer KMP scripts call kernel-scriptlets
+            if "module-init-tools/kernel-scriptlets/kmp-post" in line:
+                return True
 
         return False
 

--- a/src/soliddriver_checks/api/kmp.py
+++ b/src/soliddriver_checks/api/kmp.py
@@ -260,7 +260,8 @@ class KMPAnalysis:
                         if uk.strip() == kmp_a.strip():
                             unmatched_kmp_alias.remove(uk)
                             break
-                    break
+                # Keep looping. Can match more than one KMP modalias
+                # Need to remove all from unmatched list.
             if not found:
                 unmatched_ker_alias.append(ker_a)
 


### PR DESCRIPTION
later KMPs do not call weak-modules2 directly but rather call kernel-scriptlets that will call weak-modules2